### PR TITLE
Fixed config file read routine exception and seek

### DIFF
--- a/acertmgr.py
+++ b/acertmgr.py
@@ -205,10 +205,12 @@ if __name__ == "__main__":
                 import json
 
                 config = json.load(config_fd)
-            except json.JSONDecodeError:
+            except ValueError:
                 import yaml
 
+                config_fd.seek(0)
                 config = yaml.load(config_fd)
+
     if 'defaults' not in config:
         config['defaults'] = {}
     if 'server_key' not in config:
@@ -226,9 +228,10 @@ if __name__ == "__main__":
 
                     for entry in json.load(config_fd).items():
                         config['domains'].append(entry)
-                except json.JSONDecodeError:
+                except ValueError:
                     import yaml
 
+                    config_fd.seek(0)
                     for entry in yaml.load(config_fd).items():
                         config['domains'].append(entry)
 


### PR DESCRIPTION
  * Fixed exception of exception json.JSONDecodeError not found
    JSONDecodeError is a subclass of ValueError and is consistantly
    available in python2.7 and >3
  * seek config_fd back to begin before try to read handle as yaml